### PR TITLE
Accepting others model to generate with SAT CFe

### DIFF
--- a/src/Elements/ICMSIPI/C100.php
+++ b/src/Elements/ICMSIPI/C100.php
@@ -42,7 +42,7 @@ class C100 extends Element implements ElementInterface
         ],
         'COD_MOD' => [
             'type' => 'string',
-            'regex' => '^(01|1B|04|55|65)$',
+            'regex' => '^.{2}$',
             'required' => true,
             'info' => 'Código do modelo do documento fiscalValor total do estoque',
             'format' => ''


### PR DESCRIPTION
Preciso gerar EFD com documentos CFe gerados via SAT
A lib não aceita o model 59 de acordo com a tabela 4.1.1 da [Nota Técnica](http://sped.rfb.gov.br/estatico/E4/4127A9B021269D7EC72D7D2FE364B0ACE2FF5E/Nota%20T%c3%a9cnica%20EFD%20ICMS%20IPI%202018.001%20v2.00%20-%20Manual%20de%20Orienta%c3%a7%c3%a3o.pdf)