### PR TITLE
Adicionado parametro IND_REST_RESSARC_COMPL_ICMS ao elemento Z1010.

### DIFF
--- a/src/Elements/ICMSIPI/Z1010.php
+++ b/src/Elements/ICMSIPI/Z1010.php
@@ -128,6 +128,15 @@ class Z1010 extends Element implements ElementInterface
                 .'N - Não',
             'format'   => ''
         ],
+	'IND_REST_RESSARC_COMPL_ICMS' => [
+            'type'     => 'string',
+            'regex'    => '^[S|N]$',
+            'required' => true,
+            'info'     => 'Reg. 1250 – Possui informações consolidadas de saldos de restituição, ressarcimento e complementação do ICMS?'
+                .'S– Sim '
+                .'N - Não',
+            'format'   => ''
+        ],
     ];
 
     /**


### PR DESCRIPTION
Adicionado parametro IND_REST_RESSARC_COMPL_ICMS ao elemento Z1010, conforme disposto no Manual de Orientação da Escrituração Fiscal Digital – EFD ICMS IPI (NT 2019.001 v 1.0 (leiaute versão 014), pagina 138 e 122.
 http://sped.rfb.gov.br/estatico/02/3F543AF63FB0C58D8B526E855EAAC4297A1816/2019_05_21_NT_EFD%20ICMS%20IPI%202018.001%20v3%20-%20MOC%20para%20publica%c3%a7%c3%a3o.pdf
