### PR TITLE
Campo inexistente para o Elemento D500

### DIFF
--- a/src/Elements/ICMSIPI/D500.php
+++ b/src/Elements/ICMSIPI/D500.php
@@ -62,21 +62,6 @@ class D500 extends Element implements ElementInterface
             'info' => 'Subsérie do documento fiscal ',
             'format' => ''
         ],
-        'COD_CONS' => [
-            'type'     => 'string',
-            'regex'    => '^0[1|2|3|4|5|6|7|8]$',
-            'required' => true,
-            'info'     => 'Código de classe de consumo de energia elétrica: '
-            .'01 - Comercial '
-            .'02 - Consumo Próprio '
-            .'03 - Iluminação Pública '
-            .'04 - Industrial '
-            .'05 - Poder Público '
-            .'06 - Residencial '
-            .'07 - Rural '
-            .'08 -Serviço Público',
-            'format'   => ''
-        ],
         'NUM_DOC' => [
             'type' => 'numeric',
             'regex' => '^([0-9]{1,9})?$',


### PR DESCRIPTION
Removendo COD_CONS do Elemento D500. Esse campo não existe para o D500 conforme manual mais recente na data deste commit.

Em anexo o manual usado como referência.

[2019.05.21_GUIA PRÁTICO DA EFD - Versão 3.0.3 - v3 para publicação.pdf](https://github.com/nfephp-org/sped-efd/files/4794782/2019.05.21_GUIA.PRATICO.DA.EFD.-.Versao.3.0.3.-.v3.para.publicacao.pdf)
