### PR TITLE
Fix C140 validate IND_TIT

### DIFF
--- a/src/Elements/ICMSIPI/C140.php
+++ b/src/Elements/ICMSIPI/C140.php
@@ -22,7 +22,7 @@ class C140 extends Element implements ElementInterface
         ],
         'IND_TIT' => [
             'type' => 'string',
-            'regex' => '^(01|02|03|99)$',
+            'regex' => '^(00|01|02|03|99)$',
             'required' => true,
             'info' => 'Indicador do tipo de título de crédito',
             'format' => ''


### PR DESCRIPTION
Adicionado opção "00" para o campo IND_TIT, de acordo com o manual Guia Prático EFD-ICMS/IPI – Versão 3.0.6, atualização: 19 de Novembro de 2020.