### PR TITLE
Ajuste regra de validação campo 8 - E520

### DIFF
--- a/src/Elements/ICMSIPI/E520.php
+++ b/src/Elements/ICMSIPI/E520.php
@@ -104,7 +104,7 @@ class E520 extends Element implements ElementInterface
                     - $this->values->vl_sd_ant_ipi
                     - $this->values->vl_cred_ipi
                     - $this->values->vl_oc_ipi;
-        if ($somatorio >= 0 && $this->values->vl_sd_ipi == 0) {
+        if ($somatorio >= 0 && $this->values->vl_sd_ipi != $somatorio && $this->values->vl_sc_ipi != 0) {
             throw new \InvalidArgumentException("[" . self::REG . "] Se a soma dos campos VL_DEB_IPI e VL_OD_IPI "
             ."menos a soma dos campos VL_SD_ANT_IPI, VL_CRED_IPI e VL_OC_IPI for maior ou igual a “0” (zero), então "
             ."o campo 08 (VL_SD_IPI) deve ser igual ao resultado da expressão, e o valor do campo VL_SC_IPI deve ser "


### PR DESCRIPTION
Ajuste na RV.
Quando gerado bloco K por exemplo, com valores zerados neste registro (E520), o arquivo passa pelo validador SPED ICMS IPI porém não passa por essa regra.