### PR TITLE
Correção da validação do empty no E116

### DIFF
--- a/examples/ICMS_IPI/E116.php
+++ b/examples/ICMS_IPI/E116.php
@@ -11,7 +11,7 @@ $std->VL_OR = 800.97;
 $std->DT_VCTO = 26102018;
 $std->COD_REC = '49435793';
 $std->NUM_PROC = '39457202334';
-$std->IND_PROC = '2';
+$std->IND_PROC = '0';
 $std->PROC = 'Descrição resumida do processo que embasou o lançamento';
 $std->TXT_COMPL = 'Descrição complementar das obrigações a recolher.';
 $std->MES_REF = 102018;
@@ -19,7 +19,7 @@ $std->MES_REF = 102018;
 try {
     $b0 = new E116($std);
     echo "{$b0}".'<br>';
-    echo '|E116|090|800.97|26102018|49435793|39457202334|2|Descrição resumida do processo que embasou o lançamento|Descrição complementar das obrigações a recolher.|102018|<br>';
+    echo '|E116|090|800.97|26102018|49435793|39457202334|0|Descrição resumida do processo que embasou o lançamento|Descrição complementar das obrigações a recolher.|102018|<br>';
 } catch (\Exception $e) {
     echo $e->getMessage();
 }

--- a/src/Elements/ICMSIPI/E116.php
+++ b/src/Elements/ICMSIPI/E116.php
@@ -39,7 +39,7 @@ class E116 extends Element implements ElementInterface
             'regex'    => '^.*$',
             'required' => true,
             'info'     => 'Código de receita referente à obrigação, próprio '
-            .'da unidade da federação, conforme legislação estadual.',
+                . 'da unidade da federação, conforme legislação estadual.',
             'format'   => ''
         ],
         'NUM_PROC' => [
@@ -54,10 +54,10 @@ class E116 extends Element implements ElementInterface
             'regex'    => '^[0|1|2|9]$',
             'required' => false,
             'info'     => 'Indicador da origem do processo: '
-            .'0- SEFAZ;'
-            .'1- Justiça Federal;'
-            .'2- Justiça Estadual;'
-            .'9- Outros',
+                . '0- SEFAZ;'
+                . '1- Justiça Federal;'
+                . '2- Justiça Estadual;'
+                . '9- Outros',
             'format'   => ''
         ],
         'PROC' => [
@@ -100,9 +100,9 @@ class E116 extends Element implements ElementInterface
          * Campo 06 (NUM_PROC) Validação: se este campo estiver preenchido, os campos
          * IND_PROC e PROC também devem estar preenchidos.
          */
-        if (!empty($this->std->num_proc) && (empty($this->std->ind_proc) || empty($this->std->proc))) {
+        if ($this->std->num_proc !== null && ($this->std->ind_proc === null || $this->std->proc === null)) {
             throw new \InvalidArgumentException("[" . self::REG . "] Se o campo NUM_PROC estiver preenchido, "
-            ."os campos IND_PROC e PROC também devem estar preenchidos.");
+                . "os campos IND_PROC e PROC também devem estar preenchidos.");
         }
     }
 }


### PR DESCRIPTION
No Registro E116, quando o campo IND_PROC era preenchido com o caractere '0' era considerado empty pelo php, mas era um valor válido para o campo.