### PR TITLE
Acrescentando novos campos no C500

### DIFF
--- a/src/Elements/ICMSIPI/C500.php
+++ b/src/Elements/ICMSIPI/C500.php
@@ -242,6 +242,56 @@ class C500 extends Element implements ElementInterface
             'required' => false,
             'info'     => 'Código da conta analítica contábil debitada/creditada',
             'format'   => ''
+        ],
+        'COD_MOD_DOC_REF' => [
+            'type' => 'string',
+            'regex' => '^.{2}$',
+            'required' => false,
+            'info' => 'Código do modelo do documento fiscal'
+            . 'referenciado, conforme a Tabela 4.1.1',
+            'format' => ''
+        ],
+        'HASH_DOC_REF' => [
+            'type' => 'string',
+            'regex' => '^(\d{32})$',
+            'required' => false,
+            'info' => 'Código de autenticação digital do registro (Convênio 115/2003).',
+            'format' => ''
+        ],
+        'SER_DOC_REF' => [
+            'type' => 'string',
+            'regex' => '^.{0,4}$',
+            'required' => false,
+            'info' => 'Série do documento fiscal referenciado',
+            'format' => ''
+        ],
+        'NUM_DOC_REF' => [
+            'type' => 'numeric',
+            'regex' => '^(\d{1,9})$',
+            'required' => true,
+            'info' => 'Número do documento fiscal referenciado',
+            'format' => ''
+        ],
+        'MES_DOC_REF' => [
+            'type' => 'string',
+            'regex' => '^(\d{6})$',
+            'required' => false,
+            'info' => 'Mês e ano da emissão do documento fiscal referenciado',
+            'format' => ''
+        ],
+        'ENER_INJET' => [
+            'type' => 'numeric',
+            'regex' => '^\d+(\.\d*)?|\.\d+$',
+            'required' => false,
+            'info' => 'Energia injetada',
+            'format' => '15v2'
+        ],
+        'OUTRAS_DED' => [
+            'type' => 'numeric',
+            'regex' => '^\d+(\.\d*)?|\.\d+$',
+            'required' => false,
+            'info' => 'Outras deduções',
+            'format' => '15v2'
         ]
     ];
 


### PR DESCRIPTION
Novos campos foram acrescentados ao registro C500, conforme a documentação disponível na página 133 em: http://sped.rfb.gov.br/estatico/8D/519392B83F160FA92AF2A21532ADDC16703E1B/Guia%20Pr%c3%a1tico%20EFD%20-%20Vers%c3%a3o%203.0.8.pdf
