### PR TITLE
Correção na validação

### DIFF
--- a/src/Elements/Contribuicoes/C175.php
+++ b/src/Elements/Contribuicoes/C175.php
@@ -155,7 +155,7 @@ class C175 extends Element implements ElementInterface
         }
         $multiplicacao = null;
         if (!empty($this->values->vl_bc_cofins) && !empty($this->values->aliq_cofins)) {
-            $multiplicacao = $this->values->vl_bc_cofins * $this->values->aliq_cofins;
+            $multiplicacao = $this->values->vl_bc_cofins * $this->values->aliq_cofins/100;
         }
         if (!empty($this->values->quant_bc_cofins) && !empty($this->values->aliq_cofins_quant)) {
             $multiplicacao = $this->values->quant_bc_cofins * $this->values->aliq_cofins_quant;


### PR DESCRIPTION
É necessário converter o valor em percentual em decimal, para validar corretamente. (Ex: 3.0% deve ser 0.03, para multiplicar pela base de cálculo e obter o valor correto do COFINS)