### PR TITLE
Corrige validação do CAMPO 06 (NUM_PROC) no registro E116

### DIFF
--- a/src/Elements/ICMSIPI/E116.php
+++ b/src/Elements/ICMSIPI/E116.php
@@ -100,7 +100,7 @@ class E116 extends Element implements ElementInterface
          * Campo 06 (NUM_PROC) Validação: se este campo estiver preenchido, os campos
          * IND_PROC e PROC também devem estar preenchidos.
          */
-        if (!empty($this->std->num_proc) && (empty($this->std->ind_proc) || empty($this->std->proc))) {
+        if (!empty($this->std->num_proc) && (!strlen($this->std->ind_proc) || empty($this->std->proc))) {
             $this->errors[] = "[" . self::REG . "] Se o campo NUM_PROC estiver preenchido, "
             . "os campos IND_PROC e PROC também devem estar preenchidos.";
         }


### PR DESCRIPTION
Problema:
Quando o campo 07 `IND_PROC` do registro E116 possui o valor '0' retorna a excessão: 
`Se o campo NUM_PROC estiver preenchido, os campos IND_PROC e PROC também devem estar preenchidos.`

Conforme o manual do SPED FISCAL, no registro E116 o campo 07 `IND_PROC` pode receber os valores `0, 1, 2, e 9`.

Solução:
O valor 0 mesmo que passado como string é considerado pela função `empty` como vazio, então a solução mais simples encontrada é verificar a quantidade de caracteres utilizando o `strlen`.