### PR TITLE
Atualiza validação do campo TXT no registro 0450

### DIFF
--- a/src/Elements/ICMSIPI/Z0450.php
+++ b/src/Elements/ICMSIPI/Z0450.php
@@ -40,7 +40,7 @@ class Z0450 extends Element implements ElementInterface
         ],
         'TXT' => [
             'type'     => 'string',
-            'regex'    => '^.{1,1000}$',
+            'regex'    => '^.{1,255}$',
             'required' => true,
             'info'     => 'Texto livre da informação complementar existente no documento fiscal',
             'format'   => ''


### PR DESCRIPTION
Problema: 
- No manual do SPED não é informado um tamanho especifico para o campo TXT no registro 0450;
- A validação da classe Z0450 permite informar até 1000 caracteres;

Ao validar no PVA apresenta erro informando que o tamanho do campo é inválido.

Solução:

Alterado a validação para permitir no máximo 255 que é o que o validador do SPED aceita.