### PR TITLE
Update C195.php

### DIFF
--- a/src/Elements/Contribuicoes/C195.php
+++ b/src/Elements/Contribuicoes/C195.php
@@ -110,7 +110,7 @@ class C195 extends Element
     {
 
         $multiplicacao = $this->values->vl_bc_cofins * $this->values->aliq_cofins;
-        if ($this->values->quant_bc_cofins > 0) {
+        if (isset($this->values->quant_bc_cofins) && $this->values->quant_bc_cofins > 0) {
             $multiplicacao = $this->values->quant_bc_cofins * $this->values->aliq_cofins_quant;
         }
 


### PR DESCRIPTION
Quando nao infomado o atributo  quant_bc_cofins (enviar '') dispara a seguinte exception.. mandando valor zerado, nao da exception porém da erro no validador da Sefaz

"file": "/var/www/pdvx-web/vendor/nfephp-org/sped-efd/src/Elements/Contribuicoes/C195.php",
"line": 113,
"status": "error",
"message": "Undefined property: stdClass::$quant_bc_cofins"