### PR TITLE
Adiciona campo VL_UNIT_CONV no registro C180

### DIFF
--- a/src/Elements/ICMSIPI/C180.php
+++ b/src/Elements/ICMSIPI/C180.php
@@ -40,6 +40,14 @@ class C180 extends Element
             'info'     => 'Unidade adotada para informar o campo QUANT_CONV.',
             'format'   => ''
         ],
+        'VL_UNIT_CONV' => [
+            'type'     => 'numeric',
+            'regex'    => '^\d+(\.\d*)?|\.\d+$',
+            'required' => true,
+            'info'     => 'Valor unitário da mercadoria, considerando a unidade utilizada ' 
+            . 'para informar o campo QUANT_CONV.',
+            'format'   => '15v6'
+        ],
         'VL_UNIT_ICMS_OP_CONV' => [
             'type'     => 'numeric',
             'regex'    => '^\d+(\.\d*)?|\.\d+$',


### PR DESCRIPTION
Identificamos que no manual do SPED no registro C180 pag 94 foi adicionado o campo VL_UNIT_CONV, então solicitamos a adição desse novo campo na biblioteca, desde já agradecemos a atenção.

![image](https://github.com/nfephp-org/sped-efd/assets/80511716/e760d6cf-79df-4b7e-bde6-42fa1a18dce1)
